### PR TITLE
[#39] Product Service를 마이크로서비스로 변환

### DIFF
--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/AvalancheProductApplication.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/AvalancheProductApplication.java
@@ -7,7 +7,7 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @EnableDiscoveryClient
 @SpringBootApplication
-@EnableFeignClients(basePackages = "site.leesoyeon.avalanche.product.client")
+@EnableFeignClients(basePackages = "site.leesoyeon.avalanche.product.infrastructure.external.client")
 public class AvalancheProductApplication {
 
     public static void main(String[] args) {

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/application/config/AsyncConfig.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/application/config/AsyncConfig.java
@@ -1,0 +1,46 @@
+package site.leesoyeon.avalanche.product.application.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.context.annotation.Bean;
+
+import java.util.concurrent.Executor;
+
+/**
+ * 이 클래스는 Spring 애플리케이션에서 비동기 처리를 활성화하고,
+ * 비동기 작업을 효율적으로 처리하기 위한 커스텀 스레드 풀 실행기를 설정하는 구성 클래스입니다.
+ *
+ * <p>비동기 작업이란, 메인 스레드와 별도로 실행되는 작업으로, 이를 통해 애플리케이션의 성능을
+ * 향상시키고, 긴 작업이 메인 스레드를 차단하지 않도록 합니다. 이 클래스는 이를 위해
+ * {@link ThreadPoolTaskExecutor}를 설정하여 비동기 작업에 사용할 스레드 풀의 크기, 큐 용량,
+ * 스레드 이름 접두사 등을 지정합니다.</p>
+ *
+ * <p>주요 구성 요소:
+ * <ul>
+ *   <li>{@code CorePoolSize} - 기본 스레드 풀 크기, 즉 항상 유지되는 최소 스레드 수를 지정합니다.</li>
+ *   <li>{@code MaxPoolSize} - 최대 스레드 풀 크기를 지정합니다. 이 크기만큼의 스레드가 동시에 실행될 수 있습니다.</li>
+ *   <li>{@code QueueCapacity} - 작업 큐의 최대 수용량을 지정합니다. 대기 중인 작업의 수가 이 값을 초과하면 새로운 작업은 거부됩니다.</li>
+ *   <li>{@code ThreadNamePrefix} - 스레드 이름의 접두사를 지정하여 스레드를 구분하기 쉽게 합니다.</li>
+ * </ul>
+ * </p>
+ *
+ * <p>이 설정은 @EnableAsync 어노테이션을 통해 비동기 메서드 호출을 활성화하며,
+ * 애플리케이션 내에서 @Async 어노테이션이 있는 메서드를 호출할 때 사용됩니다.</p>
+ */
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("AsyncThread-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/application/service/InventoryService.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/application/service/InventoryService.java
@@ -1,0 +1,63 @@
+package site.leesoyeon.avalanche.product.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.leesoyeon.avalanche.product.infrastructure.external.dto.OrderContext;
+import site.leesoyeon.avalanche.product.domain.model.ProductInfo;
+import site.leesoyeon.avalanche.product.domain.model.Product;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InventoryService {
+
+    private final ProductService productService;
+
+    @Transactional
+    public OrderContext deductInventory(OrderContext context) {
+        try {
+            ProductInfo orderItem = context.productInfo();
+            Product product = productService.findById(orderItem.productId());
+
+            if (product.getStock() < context.quantity()) {
+                log.error("재고 부족: 제품 ID: {}, 요청 수량: {}, 현재 재고: {}",
+                        product.getProductId(), context.quantity(), product.getStock());
+                return context.inventoryDeductionFailed("재고 부족: 요청된 수량을 처리할 수 없습니다.");
+            }
+
+            int originalStock = product.getStock();
+            product.reduceStock(context.quantity());
+            productService.saveProduct(product);
+
+            log.info("재고 감소 완료. 제품 ID: {}, 감소량: {}, 이전 재고: {}, 현재 재고: {}",
+                    product.getProductId(), context.quantity(), originalStock, product.getStock());
+
+            return context.inventoryDeducted();
+
+        } catch (Exception e) {
+            return context.inventoryDeductionFailed("재고 감소 중 오류 발생: " + e.getMessage());
+        }
+    }
+
+    @Transactional
+    public OrderContext refundInventory(OrderContext context) {
+        try {
+            ProductInfo orderItem = context.productInfo();
+            Product product = productService.findById(orderItem.productId());
+
+            int originalStock = product.getStock();
+            product.increaseStock(context.quantity());
+            productService.saveProduct(product);
+
+            log.info("보상 트랜잭션: 재고 복구 완료. 제품 ID: {}, 증가량: {}, 이전 재고: {}, 현재 재고: {}",
+                    product.getProductId(), context.quantity(), originalStock, product.getStock());
+
+            return context.inventoryRefunded();
+        } catch (Exception e) {
+            return context.inventoryDeductionFailed("재고 복구 중 오류 발생: " + e.getMessage());
+        }
+    }
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/application/service/ProductService.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/application/service/ProductService.java
@@ -1,0 +1,76 @@
+package site.leesoyeon.avalanche.product.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.leesoyeon.avalanche.product.shared.api.ApiStatus;
+import site.leesoyeon.avalanche.product.presentation.dto.ProductCreateRequest;
+import site.leesoyeon.avalanche.product.presentation.dto.ProductDetailResponse;
+import site.leesoyeon.avalanche.product.presentation.dto.ProductListResponse;
+import site.leesoyeon.avalanche.product.presentation.dto.ProductUpdateRequest;
+import site.leesoyeon.avalanche.product.domain.model.Product;
+import site.leesoyeon.avalanche.product.shared.enums.ProductStatus;
+import site.leesoyeon.avalanche.product.infrastructure.exception.ProductException;
+import site.leesoyeon.avalanche.product.infrastructure.persistence.repository.ProductRepository;
+import site.leesoyeon.avalanche.product.application.util.ProductMapper;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+    private final ProductMapper productMapper;
+
+    @Transactional
+    public UUID createProduct(ProductCreateRequest request) {
+        Product product = productMapper.toEntity(request);
+        Product savedProduct = productRepository.save(product);
+        return savedProduct.getProductId();
+    }
+
+    @Transactional(readOnly = true)
+    public ProductDetailResponse getProduct(UUID id) {
+        Product product = findById(id);
+        return productMapper.toDetailResponse(product);
+    }
+
+    @Transactional(readOnly = true)
+    public ProductListResponse getProductList() {
+        List<Product> products = productRepository.findAll();
+        List<ProductDetailResponse> productDetailsList = products.stream()
+                .map(productMapper::toDetailResponse)
+                .collect(Collectors.toList());
+        return new ProductListResponse(productDetailsList);
+    }
+
+    @Transactional
+    public void updateProduct(ProductUpdateRequest request) {
+        Product product = findById(request.productId());
+        productMapper.updateEntityFromRequest(request, product);
+    }
+
+    @Transactional
+    public void deactivateProduct(UUID id) {
+        Product product = findById(id);
+        product.updateStatus(ProductStatus.DISCONTINUED);
+    }
+
+    @Transactional
+    public void saveProduct(Product product) {
+        productRepository.save(product);
+    }
+
+//     ============================================
+//                 Protected Methods
+//     ============================================
+
+    protected Product findById(UUID id) {
+        return productRepository.findById(id).orElseThrow(() -> new ProductException(ApiStatus.NOT_FOUND_PRODUCT));
+    }
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/application/util/Constants.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/application/util/Constants.java
@@ -1,0 +1,26 @@
+package site.leesoyeon.avalanche.product.application.util;
+
+public final class Constants {
+
+   // API
+   public static final String API_VERSION = "/api/v1";
+   public static final String PRODUCT_API_BASE = API_VERSION + "/products";
+   public static final String SUCCESS_STATUS = "SUCCESS";
+   public static final String ERROR_STATUS = "ERROR";
+   public static final String CONTENT_TYPE_JSON = "application/json";
+
+   // Product-related
+   public static final String PRODUCT_CACHE_KEY_PREFIX = "PRODUCT::";
+   public static final long PRODUCT_CACHE_EXPIRE_TIME = 60 * 60 * 24L; // 24시간
+   public static final int MAX_PRODUCT_NAME_LENGTH = 100;
+   public static final int MIN_PRODUCT_NAME_LENGTH = 3;
+
+   // Cache
+   public static final String CACHE_KEY_PREFIX = "CACHE::";
+   public static final long DEFAULT_CACHE_EXPIRE_TIME = 60 * 60L; // 1시간
+   public static final String CACHE_USER = "USER::";
+
+   private Constants() {
+      throw new IllegalStateException("이 클래스는 인스턴스를 생성할 수 없습니다.");
+   }
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/application/util/ProductMapper.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/application/util/ProductMapper.java
@@ -1,0 +1,27 @@
+package site.leesoyeon.avalanche.product.application.util;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import site.leesoyeon.avalanche.product.presentation.dto.ProductCreateRequest;
+import site.leesoyeon.avalanche.product.presentation.dto.ProductDetailResponse;
+import site.leesoyeon.avalanche.product.presentation.dto.ProductUpdateRequest;
+import site.leesoyeon.avalanche.product.domain.model.Product;
+import site.leesoyeon.avalanche.product.shared.enums.ProductStatus;
+import site.leesoyeon.avalanche.product.shared.enums.Rarity;
+
+
+@Mapper(componentModel = "spring", imports = {ProductStatus.class, Rarity.class}, nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+public interface ProductMapper {
+
+    @Mapping(target = "productId", ignore = true)
+    @Mapping(target = "version", ignore = true)
+    Product toEntity(ProductCreateRequest request);
+
+    @Mapping(target = "productId", ignore = true)
+    void updateEntityFromRequest(ProductUpdateRequest request, @MappingTarget Product product);
+
+    ProductDetailResponse toDetailResponse(Product product);
+
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/domain/model/BaseTimeEntity.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/domain/model/BaseTimeEntity.java
@@ -1,0 +1,43 @@
+package site.leesoyeon.avalanche.product.domain.model;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * * BaseTimeEntity는 엔티티 클래스에 공통적으로 사용되는
+ * 생성 시간과 수정 시간을 자동으로 관리하기 위한
+ * 기본 클래스를 제공합니다.
+ *
+ * <p>* 이 클래스를 상속받는 엔티티 클래스는
+ * 해당 엔티티가 생성되거나 수정될 때
+ * 자동으로 시간을 기록하게 됩니다.</p>
+ *
+ * <pre>{@code
+ * //예시
+ * @Entity
+ * public class User extends BaseTimeEntity {
+ *     // 사용자 필드들...
+ * }
+ * }</pre>
+ */
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/domain/model/Product.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/domain/model/Product.java
@@ -1,0 +1,81 @@
+package site.leesoyeon.avalanche.product.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+import site.leesoyeon.avalanche.product.shared.enums.ProductStatus;
+import site.leesoyeon.avalanche.product.shared.enums.Rarity;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Table(name = "products")
+public class Product extends BaseTimeEntity {
+
+    @Id
+    @UuidGenerator
+    @Column(name = "product_id", updatable = false, nullable = false)
+    private UUID productId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Rarity rarity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProductStatus status;
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal price;
+
+    @Column(name = "category_name", nullable = false)
+    private String categoryName;
+
+    @Column(nullable = false)
+    private Integer stock;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "probability_multiplier")
+    private Double probabilityMultiplier;
+
+    @Version
+    @Column(nullable = false)
+    private Long version;
+
+    public double getEffectiveDropRate() {
+        double baseRate = rarity.getBaseDropRate();
+        return probabilityMultiplier != null ? baseRate * probabilityMultiplier : baseRate;
+    }
+
+    public void updateStatus(ProductStatus status) {
+        this.status = status;
+    }
+
+    public void increaseStock(int quantity) {
+        this.stock += quantity;
+    }
+
+    public void reduceStock(int quantity) {
+        if (this.stock < quantity) {
+            throw new IllegalArgumentException("재고가 부족합니다.");
+        }
+        this.stock -= quantity;
+    }
+
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/domain/model/ProductInfo.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/domain/model/ProductInfo.java
@@ -1,0 +1,59 @@
+package site.leesoyeon.avalanche.product.domain.model;
+
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder(toBuilder = true)
+public record ProductInfo(
+        UUID productId,
+        String name,
+        Integer unitPrice,
+        Integer quantity,
+
+        boolean success,
+        String errorMessage,
+        String state,
+        boolean inventoryStepCompleted
+
+) {
+    // 사가 실패 시 호출
+    public ProductInfo fail(String errorMessage) {
+        return this.toBuilder()
+                .success(false)
+                .errorMessage(errorMessage)
+                .state("FAILED")
+                .build();
+    }
+
+    //===================================
+    //           재고 관리 메서드
+    //===================================
+
+    // 재고 차감 성공 시 호출
+    public ProductInfo inventoryDeducted() {
+        return this.toBuilder()
+                .state("INVENTORY_DEDUCTED")
+                .inventoryStepCompleted(true)
+                .success(true)
+                .build();
+    }
+
+    // 재고부족으로 작업이 중단될 때 호출
+    public ProductInfo inventoryDepleted(String errorMessage) {
+        return this.toBuilder()
+                .state("INVENTORY_DEPLETED")
+                .success(false)
+                .inventoryStepCompleted(false)
+                .errorMessage(errorMessage)
+                .build();
+    }
+
+    // 재고 복구 시 호출
+    public ProductInfo inventoryRefunded() {
+        return this.toBuilder()
+                .inventoryStepCompleted(false)
+                .build();
+    }
+
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/config/LoggingAspect.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/config/LoggingAspect.java
@@ -1,0 +1,43 @@
+package site.leesoyeon.avalanche.product.infrastructure.config;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * 이 클래스는 AOP(Aspect-Oriented Programming)를 사용하여 메서드 실행 전후로 로깅을 수행하는 로깅 관점을 정의합니다.
+ *
+ * <p>로깅 관점은 애플리케이션의 특정 관심사를 모듈화하여 관리할 수 있게 해주며, 이 클래스는 특히 서비스 레이어의 메서드 실행 시간과
+ * 호출 정보를 로깅하는 데 사용됩니다. 이를 통해 성능 모니터링과 디버깅에 도움을 줄 수 있습니다.</p>
+ *
+ * <p>주요 기능:
+ * <ul>
+ *   <li>{@code @Around} - 지정된 패턴과 일치하는 메서드 실행 전후에 코드 블록을 실행합니다. 이 경우, 서비스 레이어의 모든 메서드 실행을 감싸고 있습니다.</li>
+ *   <li>{@code logMethodExecution} - 메서드 실행 전후에 실행 시간을 측정하고, 메서드 이름과 실행 시간을 로깅합니다.</li>
+ *   <li>로그는 SLF4J를 사용하여 기록되며, 메서드 실행 전에 시작 로그를, 실행 후에 완료 로그를 기록합니다.</li>
+ * </ul>
+ * </p>
+ *
+ * <p>이 설정을 통해 애플리케이션 내의 서비스 레이어에서 성능 문제를 파악하거나 특정 메서드 호출의 빈도와 실행 시간을 추적할 수 있습니다.</p>
+ */
+@Aspect
+@Component
+public class LoggingAspect {
+
+    private static final Logger logger = LoggerFactory.getLogger(LoggingAspect.class);
+
+    @Around("execution(* site.leesoyeon.probabilityrewardsystem..service.*.*(..))")
+    public Object logMethodExecution(ProceedingJoinPoint joinPoint) throws Throwable {
+        String methodName = joinPoint.getSignature().getName();
+        logger.info("Executing method: {}", methodName);
+        long start = System.currentTimeMillis();
+        Object result = joinPoint.proceed();
+        long executionTime = System.currentTimeMillis() - start;
+        logger.info("Executed method: {} in {} ms", methodName, executionTime);
+        return result;
+    }
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/config/StartupLogger.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/config/StartupLogger.java
@@ -1,0 +1,25 @@
+package site.leesoyeon.avalanche.product.infrastructure.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StartupLogger implements ApplicationListener<ApplicationReadyEvent> {
+    private static final Logger logger = LoggerFactory.getLogger(StartupLogger.class);
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        logger.info("===============================================");
+        logger.info("*     ❄️   *    *       *     ❄️    *      ️ ❄️");
+        logger.info("   *           ❄️   *     *     *        *    ");
+        logger.info(" *  /\\  PROJECT AVALANCHE SERVER STARTED!   *");
+        logger.info("   /  \\  *      *     ❄️     *     *         ");
+        logger.info(" *  ||  ❄️   *             *      ❄️    *    *");
+        logger.info("    ||    SPRING BOOT POWERED SNOW SYSTEM  *  ");
+        logger.info("   /||\\    *     *    *     *    *         ❄️");
+        logger.info("===============================================");
+    }
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/config/SwaggerConfig.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package site.leesoyeon.avalanche.product.infrastructure.config;
+
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Probability Reward API")
+                        .version("1.0.0")
+                        .description("This is the API documentation for My Awesome Project"));
+    }
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/exception/GlobalExceptionHandler.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package site.leesoyeon.avalanche.product.infrastructure.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import site.leesoyeon.avalanche.product.shared.api.ApiResponse;
+import site.leesoyeon.avalanche.product.shared.api.ApiStatus;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ProductException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUserException(ProductException ex) {
+        log.error("상품 예외 발생: {}", ex.getMessage(), ex);
+        ApiResponse<Void> response = ApiResponse.error(ex.getStatus(), ex.getDebugMessage());
+        return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getStatus().getStatusCode()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleGenericException(Exception ex) {
+        log.error("예기치 않은 오류 발생: {}", ex.getMessage(), ex);
+        ApiResponse<Void> response = ApiResponse.error(ApiStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}
+

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/exception/ProductException.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/exception/ProductException.java
@@ -1,0 +1,23 @@
+package site.leesoyeon.avalanche.product.infrastructure.exception;
+
+import lombok.Getter;
+import site.leesoyeon.avalanche.product.shared.api.ApiStatus;
+
+@Getter
+public class ProductException extends RuntimeException {
+
+    private final ApiStatus status;
+    private final String debugMessage;
+
+    public ProductException(ApiStatus status) {
+        super(status.getMessage());
+        this.status = status;
+        this.debugMessage = null;
+    }
+
+    public ProductException(ApiStatus status, String debugMessage) {
+        super(status.getMessage());
+        this.status = status;
+        this.debugMessage = debugMessage;
+    }
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/external/client/OrderServiceClient.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/external/client/OrderServiceClient.java
@@ -1,0 +1,28 @@
+package site.leesoyeon.avalanche.product.infrastructure.external.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.*;
+import site.leesoyeon.avalanche.product.infrastructure.external.dto.OrderDto;
+import site.leesoyeon.avalanche.product.domain.model.ProductInfo;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@FeignClient(name = "order-service")
+public interface OrderServiceClient {
+
+    @PutMapping("/api/v1/orders")
+    void updateOrder(@RequestBody OrderDto order);
+
+    @GetMapping("/api/v1/orders/shipping/{productId}")
+    Optional<OrderDto> findByProductId(@PathVariable("productId") UUID productId);
+
+    @GetMapping("/api/v1/orders/{orderId}")
+    Optional<OrderDto> findById(@PathVariable("orderId") UUID orderId);
+
+    @PutMapping("/api/v1/orders/{orderId}")
+    void updateOrder(@PathVariable("orderId") UUID orderId, @RequestBody OrderDto orderDto);
+
+    @PatchMapping("/api/v1/orders/{orderId}/product")
+    void updateProductInfo(@PathVariable("orderId") UUID orderId, @RequestBody ProductInfo productInfo);
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/external/dto/OrderContext.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/external/dto/OrderContext.java
@@ -1,0 +1,65 @@
+package site.leesoyeon.avalanche.product.infrastructure.external.dto;
+
+import lombok.Builder;
+import site.leesoyeon.avalanche.product.domain.model.ProductInfo;
+
+import java.util.UUID;
+
+@Builder(toBuilder = true)
+public record OrderContext(
+        UUID userId,
+        UUID orderId,
+        Integer quantity,
+        ProductInfo productInfo,
+        SagaState state,
+
+        boolean inventoryStepCompleted,
+
+        boolean success,
+        String errorMessage
+) {
+
+    //===================================
+    //           재고 관리 메서드
+    //===================================
+
+    // 재고 차감 성공 시 호출
+    public OrderContext inventoryDeducted() {
+        return this.toBuilder()
+                .state(SagaState.INVENTORY_DEDUCTED)
+                .inventoryStepCompleted(true)
+                .success(true)
+                .build();
+    }
+
+    // 재고 처리 실패 시 호출
+    public OrderContext inventoryDeductionFailed(String errorMessage) {
+        return this.toBuilder()
+                .state(SagaState.INVENTORY_DEDUCTION_FAILED)
+                .inventoryStepCompleted(false)
+                .success(false)
+                .errorMessage(errorMessage)
+                .build();
+    }
+
+    // 재고 복구 시 호출
+    public OrderContext inventoryRefunded() {
+        return this.toBuilder()
+                .state(SagaState.INVENTORY_DEDUCTION_FAILED)
+                .inventoryStepCompleted(false)
+                .build();
+    }
+
+}
+
+enum SagaState {
+
+    INVENTORY_DEDUCTION_PENDING("재고 차감이 대기 중입니다."),
+    INVENTORY_DEDUCTED("재고가 성공적으로 차감되었습니다."),
+    INVENTORY_DEDUCTION_FAILED("재고 차감에 실패했습니다.");
+
+    private final String description;
+    SagaState(String description) {
+        this.description = description;
+    }
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/external/dto/OrderDto.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/external/dto/OrderDto.java
@@ -1,0 +1,13 @@
+package site.leesoyeon.avalanche.product.infrastructure.external.dto;
+
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder(toBuilder = true)
+public record OrderDto(
+        UUID orderId,
+        String status
+) {
+
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/persistence/repository/ProductRepository.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/infrastructure/persistence/repository/ProductRepository.java
@@ -1,0 +1,11 @@
+package site.leesoyeon.avalanche.product.infrastructure.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import site.leesoyeon.avalanche.product.domain.model.Product;
+
+import java.util.UUID;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, UUID> {
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/presentation/controller/ProductController.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/presentation/controller/ProductController.java
@@ -1,0 +1,72 @@
+package site.leesoyeon.avalanche.product.presentation.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import site.leesoyeon.avalanche.product.infrastructure.external.dto.OrderContext;
+import site.leesoyeon.avalanche.product.presentation.dto.ProductCreateRequest;
+import site.leesoyeon.avalanche.product.presentation.dto.ProductDetailResponse;
+import site.leesoyeon.avalanche.product.presentation.dto.ProductListResponse;
+import site.leesoyeon.avalanche.product.presentation.dto.ProductUpdateRequest;
+import site.leesoyeon.avalanche.product.application.service.InventoryService;
+import site.leesoyeon.avalanche.product.application.service.ProductService;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/product")
+public class ProductController {
+
+    private final ProductService productService;
+    private final InventoryService inventoryService;
+
+    @PostMapping("/deduct")
+    public ResponseEntity<OrderContext> deductInventory(@RequestBody OrderContext context) {
+        return ResponseEntity.status(HttpStatus.OK).body(inventoryService.deductInventory(context));
+    }
+
+    @PostMapping("/refund")
+    public ResponseEntity<OrderContext> refundInventory(@RequestBody OrderContext context) {
+        return ResponseEntity.status(HttpStatus.OK).body(inventoryService.refundInventory(context));
+    }
+
+    @PostMapping
+//    @PreAuthorize("hasRole('ROLE_MANAGER') or hasRole('ROLE_ADMIN')")
+    public ResponseEntity<UUID> createProduct(
+            @Valid @RequestBody ProductCreateRequest request) {
+        UUID response = productService.createProduct(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/{productId}")
+    public ResponseEntity<ProductDetailResponse> getProduct(
+            @PathVariable(value = "productId") UUID productId) {
+        ProductDetailResponse response = productService.getProduct(productId);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<ProductListResponse> getProduct() {
+        ProductListResponse response = productService.getProductList();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PutMapping
+//    @PreAuthorize("hasRole('ROLE_MANAGER') or hasRole('ROLE_ADMIN')")
+    public ResponseEntity<Void> updateProduct(
+            @Valid @RequestBody ProductUpdateRequest request) {
+        productService.updateProduct(request);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @DeleteMapping("/{productId}")
+//    @PreAuthorize("hasRole('ROLE_MANAGER') or hasRole('ROLE_ADMIN')")
+    public ResponseEntity<Void> deactivateProduct(
+            @PathVariable(value = "productId") UUID productId) {
+        productService.deactivateProduct(productId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/presentation/dto/ProductCreateRequest.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/presentation/dto/ProductCreateRequest.java
@@ -1,0 +1,41 @@
+package site.leesoyeon.avalanche.product.presentation.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import site.leesoyeon.avalanche.product.shared.enums.ProductStatus;
+import site.leesoyeon.avalanche.product.shared.enums.Rarity;
+
+
+import java.math.BigDecimal;
+
+public record ProductCreateRequest(
+        @NotBlank(message = "상품명은 필수 입력 항목입니다.")
+        String name,
+
+        String description,
+
+        @NotNull(message = "희귀도는 필수 선택 항목입니다.")
+        Rarity rarity,
+
+        @NotNull(message = "상품 상태는 필수 선택 항목입니다.")
+        ProductStatus status,
+
+        @NotNull(message = "가격은 필수 입력 항목입니다.")
+        @DecimalMin(value = "0.0", message = "가격은 0 이상이어야 합니다.")
+        BigDecimal price,
+
+        @NotBlank(message = "카테고리명은 필수 입력 항목입니다.")
+        String categoryName,
+
+        @NotNull(message = "수량은 필수 입력 항목입니다.")
+        @Min(value = 0, message = "수량은 0 이상이어야 합니다.")
+        Integer stock,
+
+        String imageUrl,
+
+        @DecimalMin(value = "0.0", message = "확률 배율은 0 이상이어야 합니다.")
+        Double probabilityMultiplier
+) {
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/presentation/dto/ProductDetailResponse.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/presentation/dto/ProductDetailResponse.java
@@ -1,0 +1,23 @@
+package site.leesoyeon.avalanche.product.presentation.dto;
+
+
+import site.leesoyeon.avalanche.product.shared.enums.ProductStatus;
+import site.leesoyeon.avalanche.product.shared.enums.Rarity;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record ProductDetailResponse(
+        UUID productId,
+        String name,
+        String description,
+        Rarity rarity,
+        ProductStatus status,
+        BigDecimal price,
+        String categoryName,
+        Integer stock,
+        String imageUrl,
+        Double probabilityMultiplier,
+        double effectiveDropRate
+) {
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/presentation/dto/ProductListResponse.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/presentation/dto/ProductListResponse.java
@@ -1,0 +1,8 @@
+package site.leesoyeon.avalanche.product.presentation.dto;
+
+import java.util.List;
+
+public record ProductListResponse(
+        List<ProductDetailResponse> products
+) {
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/presentation/dto/ProductUpdateRequest.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/presentation/dto/ProductUpdateRequest.java
@@ -1,0 +1,41 @@
+package site.leesoyeon.avalanche.product.presentation.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import site.leesoyeon.avalanche.product.shared.enums.ProductStatus;
+import site.leesoyeon.avalanche.product.shared.enums.Rarity;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record ProductUpdateRequest(
+
+        @NotNull
+        UUID productId,
+
+        @Size(min = 1, message = "상품명은 비어있을 수 없습니다.")
+        String name,
+
+        String description,
+
+        Rarity rarity,
+
+        ProductStatus status,
+
+        @DecimalMin(value = "0.0", message = "가격은 0 이상이어야 합니다.")
+        BigDecimal price,
+
+        @Size(min = 1, message = "카테고리명은 비어있을 수 없습니다.")
+        String categoryName,
+
+        @Min(value = 0, message = "수량은 0 이상이어야 합니다.")
+        Integer stock,
+
+        String imageUrl,
+
+        @DecimalMin(value = "0.0", message = "확률 배율은 0 이상이어야 합니다.")
+        Double probabilityMultiplier
+) {
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/shared/api/ApiResponse.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/shared/api/ApiResponse.java
@@ -1,0 +1,29 @@
+package site.leesoyeon.avalanche.product.shared.api;
+
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final int statusCode;
+    private final String message;
+    private final String debugMessage;
+    private final T data;
+
+    private ApiResponse(ApiStatus apiStatus, T data, String debugMessage) {
+        this.success = apiStatus.getStatusCode() < 400;
+        this.statusCode = apiStatus.getStatusCode();
+        this.message = apiStatus.getMessage();
+        this.debugMessage = debugMessage;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> success(ApiStatus status, T data) {
+        return new ApiResponse<>(status, data, null);
+    }
+
+    public static <T> ApiResponse<T> error(ApiStatus status, String debugMessage) {
+        return new ApiResponse<>(status, null, debugMessage);
+    }
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/shared/api/ApiStatus.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/shared/api/ApiStatus.java
@@ -1,0 +1,37 @@
+package site.leesoyeon.avalanche.product.shared.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ApiStatus {
+
+    // 200 - Success
+    SUCCESS(200, "SU", "Success"),
+
+    // 400 - Bad Request : 잘못된 요청
+    INVALID_INPUT_VALUE(400, "IIV", "입력 값이 잘못되었습니다."),
+    NOT_ENOUGH_STOCK(409, "NES", "재고가 부족합니다."),
+    INVALID_PRODUCT_ID(400, "IPI", "유효하지 않은 상품 ID입니다."),
+    INVALID_PRODUCT_STATUS(400, "IPS", "유효하지 않은 상품 상태입니다."),
+    DUPLICATE_PRODUCT_NAME(400, "DPN", "중복된 상품 이름입니다."),
+
+    // 404 - Not Found : 잘못된 리소스 접근
+    NOT_FOUND_PRODUCT(404, "NFP", "존재하지 않는 상품입니다."),
+
+    // 409 - Conflict : 중복 데이터
+    PRODUCT_ALREADY_EXISTS(409, "PAE", "이미 존재하는 상품입니다."),
+    CONFLICTING_PRODUCT_UPDATE(409, "CPU", "상품 업데이트 도중 충돌이 발생했습니다."),
+
+    // 500 - Internal Server Error
+    INTERNAL_SERVER_ERROR(500,"ISE", "데이터베이스 연결 실패"),
+    DATABASE_ERROR(500, "DBE", "데이터베이스 오류"),
+    FAILED_TO_SAVE_PRODUCT(500, "FSP", "상품 저장에 실패했습니다."),
+    FAILED_TO_UPDATE_PRODUCT(500, "FUP", "상품 업데이트에 실패했습니다."),
+    FAILED_TO_DELETE_PRODUCT(500, "FDP", "상품 삭제에 실패했습니다.");
+
+    private final int statusCode;
+    private final String code;
+    private final String message;
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/shared/enums/ProductStatus.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/shared/enums/ProductStatus.java
@@ -1,0 +1,31 @@
+package site.leesoyeon.avalanche.product.shared.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ProductStatus {
+
+    AVAILABLE("판매중", "눈송이 상점에서 구매 가능한 상태입니다."),
+    UPCOMING("출시 예정", "곧 눈송이 상점에 등장할 예정입니다."),
+    SOLD_OUT("품절", "현재 재고가 모두 소진되었습니다."),
+    DISCONTINUED("판매 중단", "더 이상 판매되지 않는 상품입니다."),
+    LIMITED_TIME("한정 판매", "특정 기간 동안만 구매 가능한 상품입니다."),
+    SEASONAL("시즌 한정", "특정 시즌에만 구매 가능한 상품입니다."),
+    MAINTENANCE("점검 중", "상품 정보 업데이트 중입니다.");
+
+    private final String displayName;
+    private final String description;
+
+    ProductStatus(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/shared/enums/Rarity.java
+++ b/avalanche-product/src/main/java/site/leesoyeon/avalanche/product/shared/enums/Rarity.java
@@ -1,0 +1,25 @@
+package site.leesoyeon.avalanche.product.shared.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum Rarity {
+
+    COMMON("흔한 눈송이", 60.0),
+    RARE("눈꽃 결정", 25.0),
+    EPIC("얼음 조각", 10.0),
+    LEGENDARY("오로라의 빛", 4.0),
+    MYTHIC("엘사의 선물", 1.0);
+
+    private final String description;
+    private final double baseDropRate;
+
+    Rarity(String description, double baseDropRate) {
+        this.description = description;
+        this.baseDropRate = baseDropRate;
+    }
+
+    public static Rarity fromString(String rarity) {
+        return valueOf(rarity.toUpperCase());
+    }
+}


### PR DESCRIPTION
### 🔄 변경 사항
- 기존 모노리스 구조에서 마이크로서비스 아키텍처로 전환하여 코드 재배치.
- `application`, `domain`, `infrastructure`, `presentation`, `shared` 등 레이어별로 코드 분리.
- 각 레이어에 맞게 서비스, 리포지토리, DTO, 예외 처리, 설정 등을 재구성.
- 서비스의 모듈화 및 유지보수성 향상.

### 🔍 관련 이슈


### ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 코드 스타일을 준수했습니다.
- [ ] 문서화(README.md 등)가 필요한 경우 업데이트했습니다.

### 🧪 테스트 방법
- [x] 직접 실행해 봄
- [ ] 유닛 테스트 수행
- [ ] 통합 테스트 수행
- [ ] 코드 리뷰만으로 충분함
- [ ] 기타 (설명 필요)
