### PR TITLE
[#41] PointTransactionService 마이크로서비스로 변환

### DIFF
--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/AvalanchePointApplication.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/AvalanchePointApplication.java
@@ -7,7 +7,7 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @EnableDiscoveryClient
 @SpringBootApplication
-@EnableFeignClients(basePackages = "site.leesoyeon.avalanche.point.client")
+@EnableFeignClients(basePackages = "site.leesoyeon.avalanche.point.infrastructure.external.client")
 public class AvalanchePointApplication {
 
     public static void main(String[] args) {

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/application/config/AsyncConfig.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/application/config/AsyncConfig.java
@@ -1,0 +1,46 @@
+package site.leesoyeon.avalanche.point.application.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.context.annotation.Bean;
+
+import java.util.concurrent.Executor;
+
+/**
+ * 이 클래스는 Spring 애플리케이션에서 비동기 처리를 활성화하고,
+ * 비동기 작업을 효율적으로 처리하기 위한 커스텀 스레드 풀 실행기를 설정하는 구성 클래스입니다.
+ *
+ * <p>비동기 작업이란, 메인 스레드와 별도로 실행되는 작업으로, 이를 통해 애플리케이션의 성능을
+ * 향상시키고, 긴 작업이 메인 스레드를 차단하지 않도록 합니다. 이 클래스는 이를 위해
+ * {@link ThreadPoolTaskExecutor}를 설정하여 비동기 작업에 사용할 스레드 풀의 크기, 큐 용량,
+ * 스레드 이름 접두사 등을 지정합니다.</p>
+ *
+ * <p>주요 구성 요소:
+ * <ul>
+ *   <li>{@code CorePoolSize} - 기본 스레드 풀 크기, 즉 항상 유지되는 최소 스레드 수를 지정합니다.</li>
+ *   <li>{@code MaxPoolSize} - 최대 스레드 풀 크기를 지정합니다. 이 크기만큼의 스레드가 동시에 실행될 수 있습니다.</li>
+ *   <li>{@code QueueCapacity} - 작업 큐의 최대 수용량을 지정합니다. 대기 중인 작업의 수가 이 값을 초과하면 새로운 작업은 거부됩니다.</li>
+ *   <li>{@code ThreadNamePrefix} - 스레드 이름의 접두사를 지정하여 스레드를 구분하기 쉽게 합니다.</li>
+ * </ul>
+ * </p>
+ *
+ * <p>이 설정은 @EnableAsync 어노테이션을 통해 비동기 메서드 호출을 활성화하며,
+ * 애플리케이션 내에서 @Async 어노테이션이 있는 메서드를 호출할 때 사용됩니다.</p>
+ */
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("AsyncThread-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/application/service/PointDeductionService.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/application/service/PointDeductionService.java
@@ -1,0 +1,52 @@
+package site.leesoyeon.avalanche.point.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.leesoyeon.avalanche.point.infrastructure.external.dto.OrderContext;
+import site.leesoyeon.avalanche.point.domain.model.PointTransaction;
+
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PointDeductionService {
+
+    private final PointTransactionService pointTransactionService;
+
+    @Transactional
+    public OrderContext deductPoints(OrderContext context) {
+        try {
+            UUID userId = context.userId();
+            Integer amount = context.transactionInfo().amount();
+            Integer lastBalance = pointTransactionService.getLastBalance(userId);
+
+            if (lastBalance < amount) {
+                log.error("포인트 부족: 사용자 ID: {}, 요청된 포인트: {}, 현재 잔액: {}", userId, amount, lastBalance);
+                return context.pointDeductionFailed("포인트 부족: 요청된 포인트를 차감할 수 없습니다.");
+            }
+            PointTransaction transaction = pointTransactionService.adjustPoints(context, lastBalance);
+            log.info("포인트 조정 완료: 사용자 ID: {}, 변경 금액: {}, 현재 잔액: {}, 활동 유형: {}",
+                    userId, transaction.getAmount(), transaction.getBalance(), transaction.getActivityType());
+
+            return context.pointDeducted(transaction.getTransactionId(), transaction.getDescription());
+        } catch (Exception e) {
+            return context.pointDeductionFailed("포인트 차감 중 오류 발생: " + e.getMessage());
+        }
+    }
+
+    @Transactional
+    public OrderContext refundPoints(OrderContext context) {
+        try {
+            Integer lastBalance = pointTransactionService.cancelTransaction(context.transactionInfo().transactionId());
+            log.info("포인트 환불 완료. 사용자 ID: {}, 환불된 포인트: {}, 현재 잔액: {}",
+                    context.userId(), context.transactionInfo().amount(), lastBalance);
+            return context.pointRefunded();
+        } catch (Exception e) {
+            return context.pointDeductionFailed("포인트 환불 중 오류 발생: " + e.getMessage());
+        }
+    }
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/application/service/PointTransactionService.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/application/service/PointTransactionService.java
@@ -1,0 +1,107 @@
+package site.leesoyeon.avalanche.point.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.leesoyeon.avalanche.point.infrastructure.external.dto.OrderContext;
+import site.leesoyeon.avalanche.point.shared.api.ApiStatus;
+import site.leesoyeon.avalanche.point.presentation.dto.ManualPointAdjustmentRequest;
+import site.leesoyeon.avalanche.point.presentation.dto.PointTransactionDetailDto;
+import site.leesoyeon.avalanche.point.presentation.dto.PointTransactionListDto;
+import site.leesoyeon.avalanche.point.presentation.dto.PointTransactionSummaryDto;
+import site.leesoyeon.avalanche.point.domain.model.PointTransaction;
+import site.leesoyeon.avalanche.point.shared.enums.ActivityType;
+import site.leesoyeon.avalanche.point.infrastructure.exception.PointTransactionException;
+import site.leesoyeon.avalanche.point.infrastructure.presentation.repository.PointTransactionRepository;
+import site.leesoyeon.avalanche.point.application.util.PointTransactionMapper;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PointTransactionService {
+
+    private final PointTransactionRepository pointTransactionRepository;
+    private final PointTransactionMapper pointTransactionMapper;
+
+    @Transactional(readOnly = true)
+    public PointTransactionDetailDto getPointTransactionDetail(UUID transactionId) {
+        PointTransaction transaction = findById(transactionId);
+        return pointTransactionMapper.toDto(transaction);
+    }
+
+    @Transactional(readOnly = true)
+    public PointTransactionListDto getPointTransactions(UUID userId, Pageable pageable) {
+        Page<PointTransactionSummaryDto> transactionsPage = pointTransactionRepository.findAllByUserId(userId, pageable);
+        return new PointTransactionListDto(transactionsPage);
+    }
+
+    @Transactional
+    public PointTransaction adjustPoints(OrderContext orderContext, Integer balance) {
+        PointTransaction pointTransaction = pointTransactionMapper.toPointTransaction(orderContext, balance);
+        return pointTransactionRepository.save(pointTransaction);
+    }
+
+    @Transactional
+    public void adjustPointsManually(ManualPointAdjustmentRequest request) {
+        Integer lastBalance = getLastBalance(request.userId());
+
+        PointTransaction pointTransaction = pointTransactionMapper.toEntity(request);
+
+        pointTransaction.updateBalance(lastBalance + request.amount());
+        pointTransactionRepository.save(pointTransaction);
+    }
+
+    @Transactional
+    public void updateProductId(UUID transactionId, UUID productId) {
+        PointTransaction transaction = findById(transactionId);
+        transaction.updateProductId(productId);
+    }
+
+    /**
+     * 특정 포인트 트랜잭션을 취소하고 환불 트랜잭션을 생성합니다.
+     *
+     * 이 메서드는 다음 작업을 수행합니다:
+     * 1. 지정된 ID로 트랜잭션을 찾습니다.
+     * 2. 찾은 트랜잭션을 취소 상태로 변경합니다.
+     * 3. 원래 트랜잭션과 반대되는 금액으로 새로운 환불 트랜잭션을 생성합니다.
+     * 4. 새로 생성된 환불 트랜잭션을 저장합니다.
+     *
+     * @param transactionId 취소할 트랜잭션의 고유 식별자
+     */
+    @Transactional
+    public Integer cancelTransaction(UUID transactionId) {
+        PointTransaction transaction = findById(transactionId);
+        transaction.cancel();
+        PointTransaction cancelTransaction = PointTransaction.builder()
+                .userId(transaction.getUserId())
+                .amount(-transaction.getAmount())
+                .balance(getLastBalance(transaction.getUserId()))
+                .activityType(ActivityType.REFUND)
+                .description("트랜잭션 취소: " + transactionId)
+                .build();
+        pointTransactionRepository.save(cancelTransaction);
+        return cancelTransaction.getBalance();
+    }
+
+//     ============================================
+//                 Protected Methods
+//     ============================================
+
+    protected PointTransaction findById(UUID transactionId) {
+        return pointTransactionRepository.findById(transactionId)
+                .orElseThrow(() -> new PointTransactionException(ApiStatus.NOT_FOUND_POINT_HISTORY));
+    }
+
+    protected void deleteById(UUID transactionId) {
+        pointTransactionRepository.deleteById(transactionId);
+    }
+
+    protected Integer getLastBalance(UUID userId) {
+        return pointTransactionRepository.findLatestActiveBalanceByUserId(userId).orElse(0);
+    }
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/application/util/Constants.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/application/util/Constants.java
@@ -1,0 +1,27 @@
+package site.leesoyeon.avalanche.point.application.util;
+
+ public final class Constants {
+
+   // API
+   public static final String API_VERSION = "/api/v1";
+   public static final String SUCCESS_STATUS = "SUCCESS";
+   public static final String ERROR_STATUS = "ERROR";
+   public static final String CONTENT_TYPE_JSON = "application/json";
+
+   // 포인트 관련 상수
+   public static final int MINIMUM_POINT_THRESHOLD = 0; // 최소 포인트 잔액
+   public static final int MAXIMUM_POINT_LIMIT = 1000000; // 최대 포인트 적립 한도
+   public static final String POINTS_TRANSACTION_PREFIX = "POINT::TRANSACTION::";
+   public static final long POINTS_CACHE_EXPIRE_TIME = 60 * 10L; // 포인트 캐시 만료 시간 10분
+   public static final String POINTS_TRANSACTION_SUCCESS = "포인트 거래가 성공적으로 완료되었습니다.";
+   public static final String POINTS_TRANSACTION_FAILURE = "포인트 거래에 실패했습니다.";
+
+   // 캐시 관련 상수
+   public static final String CACHE_KEY_PREFIX = "CACHE::";
+   public static final long DEFAULT_CACHE_EXPIRE_TIME = 60 * 60L; // 1시간
+   public static final String CACHE_USER = "USER::";
+
+    private Constants() {
+        throw new IllegalStateException("이 클래스는 인스턴스를 생성할 수 없습니다.");
+    }
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/application/util/PointTransactionMapper.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/application/util/PointTransactionMapper.java
@@ -1,0 +1,33 @@
+package site.leesoyeon.avalanche.point.application.util;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.ReportingPolicy;
+import site.leesoyeon.avalanche.point.infrastructure.external.dto.OrderContext;
+import site.leesoyeon.avalanche.point.presentation.dto.ManualPointAdjustmentRequest;
+import site.leesoyeon.avalanche.point.presentation.dto.PointTransactionDetailDto;
+import site.leesoyeon.avalanche.point.domain.model.PointTransaction;
+import site.leesoyeon.avalanche.point.shared.enums.ActivityType;
+
+@Mapper(componentModel = "spring",
+        imports = {ActivityType.class},
+        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface PointTransactionMapper {
+
+    @Mapping(target = "balance", expression = "java(0)")
+    PointTransaction toEntity(ManualPointAdjustmentRequest request);
+
+    PointTransactionDetailDto toDto(PointTransaction pointTransaction);
+
+    @Mapping(target = "userId", source = "orderContext.userId")
+    @Mapping(target = "amount", expression = "java(-orderContext.transactionInfo().amount())")
+    @Mapping(target = "balance", expression = "java(balance - orderContext.transactionInfo().amount())")
+    @Mapping(target = "activityType", source = "orderContext.transactionInfo.activityType")
+    @Mapping(target = "description", expression = "java(orderContext.transactionInfo().activityType().getDescription() + \" : \" + orderContext.productInfo().name())")
+    @Mapping(target = "orderId", source = "orderContext.orderId")
+    @Mapping(target = "productId", source = "orderContext.productInfo.productId")
+    @Mapping(target = "isCancelled", constant = "false")
+    PointTransaction toPointTransaction(OrderContext orderContext, Integer balance);
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/domain/model/BaseTimeEntity.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/domain/model/BaseTimeEntity.java
@@ -1,0 +1,43 @@
+package site.leesoyeon.avalanche.point.domain.model;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * * BaseTimeEntity는 엔티티 클래스에 공통적으로 사용되는
+ * 생성 시간과 수정 시간을 자동으로 관리하기 위한
+ * 기본 클래스를 제공합니다.
+ *
+ * <p>* 이 클래스를 상속받는 엔티티 클래스는
+ * 해당 엔티티가 생성되거나 수정될 때
+ * 자동으로 시간을 기록하게 됩니다.</p>
+ *
+ * <pre>{@code
+ * //예시
+ * @Entity
+ * public class User extends BaseTimeEntity {
+ *     // 사용자 필드들...
+ * }
+ * }</pre>
+ */
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/domain/model/PointTransaction.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/domain/model/PointTransaction.java
@@ -1,0 +1,82 @@
+package site.leesoyeon.avalanche.point.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+import site.leesoyeon.avalanche.point.shared.enums.ActivityType;
+
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+@Builder
+@Entity
+@Table(name = "point_transactions")
+public class PointTransaction extends BaseTimeEntity {
+
+    @Id
+    @UuidGenerator
+    @Column(name = "transaction_id", updatable = false, nullable = false)
+    private UUID transactionId;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false)
+    private Integer amount;
+
+    @Column(nullable = false)
+    private Integer balance;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "activity_type", nullable = false)
+    private ActivityType activityType;
+
+    @Column(name = "order_id")
+    private UUID orderId;
+
+    @Column(name = "product_id")
+    private UUID productId;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "is_cancelled", nullable = false)
+    private boolean isCancelled;
+
+    @Column(name = "expiry_date")
+    private LocalDateTime expiryDate;
+
+    @Version
+    @Column(nullable = false)
+    private Long version;
+
+    public void cancel() {
+        if (this.isCancelled) {
+            throw new IllegalStateException("이미 취소된 트랜잭션입니다.");
+        }
+        this.isCancelled = true;
+    }
+
+    public void updateBalance(Integer currentPoint) {
+        this.balance += currentPoint;
+    }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
+
+    public void updateExpiryDate(LocalDateTime expiryDate) {
+        this.expiryDate = expiryDate;
+    }
+
+    public void updateProductId(UUID productId) {
+        this.productId = productId;
+    }
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/domain/model/PointTransactionInfo.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/domain/model/PointTransactionInfo.java
@@ -1,0 +1,16 @@
+package site.leesoyeon.avalanche.point.domain.model;
+
+
+
+import site.leesoyeon.avalanche.point.shared.enums.ActivityType;
+
+import java.util.UUID;
+
+@lombok.Builder(toBuilder = true)
+public record PointTransactionInfo(
+        UUID transactionId,
+        Integer amount,
+        ActivityType activityType,
+        String description
+) {
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/config/JpaConfig.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/config/JpaConfig.java
@@ -1,0 +1,19 @@
+package site.leesoyeon.avalanche.point.infrastructure.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/config/LoggingAspect.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/config/LoggingAspect.java
@@ -1,0 +1,43 @@
+package site.leesoyeon.avalanche.point.infrastructure.config;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * 이 클래스는 AOP(Aspect-Oriented Programming)를 사용하여 메서드 실행 전후로 로깅을 수행하는 로깅 관점을 정의합니다.
+ *
+ * <p>로깅 관점은 애플리케이션의 특정 관심사를 모듈화하여 관리할 수 있게 해주며, 이 클래스는 특히 서비스 레이어의 메서드 실행 시간과
+ * 호출 정보를 로깅하는 데 사용됩니다. 이를 통해 성능 모니터링과 디버깅에 도움을 줄 수 있습니다.</p>
+ *
+ * <p>주요 기능:
+ * <ul>
+ *   <li>{@code @Around} - 지정된 패턴과 일치하는 메서드 실행 전후에 코드 블록을 실행합니다. 이 경우, 서비스 레이어의 모든 메서드 실행을 감싸고 있습니다.</li>
+ *   <li>{@code logMethodExecution} - 메서드 실행 전후에 실행 시간을 측정하고, 메서드 이름과 실행 시간을 로깅합니다.</li>
+ *   <li>로그는 SLF4J를 사용하여 기록되며, 메서드 실행 전에 시작 로그를, 실행 후에 완료 로그를 기록합니다.</li>
+ * </ul>
+ * </p>
+ *
+ * <p>이 설정을 통해 애플리케이션 내의 서비스 레이어에서 성능 문제를 파악하거나 특정 메서드 호출의 빈도와 실행 시간을 추적할 수 있습니다.</p>
+ */
+@Aspect
+@Component
+public class LoggingAspect {
+
+    private static final Logger logger = LoggerFactory.getLogger(LoggingAspect.class);
+
+    @Around("execution(* site.leesoyeon.avalanche.point..service.*.*(..))")
+    public Object logMethodExecution(ProceedingJoinPoint joinPoint) throws Throwable {
+        String methodName = joinPoint.getSignature().getName();
+        logger.info("Executing method: {}", methodName);
+        long start = System.currentTimeMillis();
+        Object result = joinPoint.proceed();
+        long executionTime = System.currentTimeMillis() - start;
+        logger.info("Executed method: {} in {} ms", methodName, executionTime);
+        return result;
+    }
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/config/StartupLogger.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/config/StartupLogger.java
@@ -1,0 +1,25 @@
+package site.leesoyeon.avalanche.point.infrastructure.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StartupLogger implements ApplicationListener<ApplicationReadyEvent> {
+    private static final Logger logger = LoggerFactory.getLogger(StartupLogger.class);
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        logger.info("===============================================");
+        logger.info("*     ❄️   *    *       *     ❄️    *      ️ ❄️");
+        logger.info("   *           ❄️   *     *     *        *    ");
+        logger.info(" *  /\\  PROJECT AVALANCHE SERVER STARTED!   *");
+        logger.info("   /  \\  *      *     ❄️     *     *         ");
+        logger.info(" *  ||  ❄️   *             *      ❄️    *    *");
+        logger.info("    ||    SPRING BOOT POWERED SNOW SYSTEM  *  ");
+        logger.info("   /||\\    *     *    *     *    *         ❄️");
+        logger.info("===============================================");
+    }
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/config/SwaggerConfig.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package site.leesoyeon.avalanche.point.infrastructure.config;
+
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Probability Reward API")
+                        .version("1.0.0")
+                        .description("This is the API documentation for My Awesome Project"));
+    }
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/exception/GlobalExceptionHandler.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/exception/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package site.leesoyeon.avalanche.point.infrastructure.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import site.leesoyeon.avalanche.point.shared.api.ApiStatus;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(PointTransactionException.class)
+    public ResponseEntity<site.leesoyeon.avalanche.product.shared.api.ApiResponse<Void>> handleUserException(PointTransactionException ex) {
+        log.error("상품 예외 발생: {}", ex.getMessage(), ex);
+        site.leesoyeon.avalanche.product.shared.api.ApiResponse<Void> response = site.leesoyeon.avalanche.product.shared.api.ApiResponse.error(ex.getStatus(), ex.getDebugMessage());
+        return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getStatus().getStatusCode()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<site.leesoyeon.avalanche.product.shared.api.ApiResponse<Void>> handleGenericException(Exception ex) {
+        log.error("예기치 않은 오류 발생: {}", ex.getMessage(), ex);
+        site.leesoyeon.avalanche.product.shared.api.ApiResponse<Void> response = site.leesoyeon.avalanche.product.shared.api.ApiResponse.error(ApiStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}
+

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/exception/PointTransactionException.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/exception/PointTransactionException.java
@@ -1,0 +1,22 @@
+package site.leesoyeon.avalanche.point.infrastructure.exception;
+
+import lombok.Getter;
+import site.leesoyeon.avalanche.point.shared.api.ApiStatus;
+@Getter
+public class PointTransactionException extends RuntimeException {
+
+    private final ApiStatus status;
+    private final String debugMessage;
+
+    public PointTransactionException(ApiStatus status) {
+        super(status.getMessage());
+        this.status = status;
+        this.debugMessage = null;
+    }
+
+    public PointTransactionException(ApiStatus status, String debugMessage) {
+        super(status.getMessage());
+        this.status = status;
+        this.debugMessage = debugMessage;
+    }
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/external/client/UserServiceClient.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/external/client/UserServiceClient.java
@@ -1,8 +1,8 @@
-package site.leesoyeon.avalanche.point.client;
+package site.leesoyeon.avalanche.point.infrastructure.external.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.*;
-import site.leesoyeon.avalanche.point.client.dto.UserDto;
+import site.leesoyeon.avalanche.point.infrastructure.external.dto.UserDto;
 
 
 import java.util.UUID;

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/external/dto/OrderContext.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/external/dto/OrderContext.java
@@ -1,0 +1,71 @@
+package site.leesoyeon.avalanche.point.infrastructure.external.dto;
+
+import lombok.Builder;
+import site.leesoyeon.avalanche.point.domain.model.PointTransactionInfo;
+
+import java.util.UUID;
+
+@Builder(toBuilder = true)
+public record OrderContext(
+        UUID userId,
+        UUID orderId,
+        Integer quantity,
+        PointTransactionInfo transactionInfo,
+        ProductInfo productInfo,
+        SagaState state,
+
+        boolean pointStepCompleted,
+        boolean success,
+        String errorMessage
+) {
+
+    //===================================
+    //          포인트 관리 메서드
+    //===================================
+
+    // 포인트 차감 성공 시 호출
+    public OrderContext pointDeducted(UUID transactionId, String description) {
+        PointTransactionInfo updatedTransactionInfo = this.transactionInfo().toBuilder()
+                .transactionId(transactionId)
+                .description(description)
+                .build();
+
+        return this.toBuilder()
+                .transactionInfo(updatedTransactionInfo)
+                .state(SagaState.POINT_DEDUCTED)
+                .pointStepCompleted(true)
+                .success(true)
+                .build();
+    }
+
+    // 포인트 차감 실패 시 호출
+    public OrderContext pointDeductionFailed(String errorMessage) {
+        return this.toBuilder()
+                .state(SagaState.POINT_DEDUCTION_FAILED)
+                .pointStepCompleted(false)
+                .success(false)
+                .errorMessage(errorMessage)
+                .build();
+    }
+
+    // 포인트 환불 시 호출
+    public OrderContext pointRefunded() {
+        return this.toBuilder()
+                .transactionInfo(null)
+                .state(SagaState.POINT_DEDUCTION_FAILED)
+                .pointStepCompleted(false)
+                .build();
+    }
+}
+
+enum SagaState {
+    POINT_DEDUCTION_PENDING("포인트 차감이 대기 중입니다."),
+    POINT_DEDUCTED("포인트가 성공적으로 차감되었습니다."),
+    POINT_DEDUCTION_FAILED("포인트 차감에 실패했습니다.");
+
+    private final String description;
+    SagaState(String description) {
+        this.description = description;
+    }
+}
+

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/external/dto/ProductInfo.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/external/dto/ProductInfo.java
@@ -1,0 +1,9 @@
+package site.leesoyeon.avalanche.point.infrastructure.external.dto;
+
+import java.util.UUID;
+
+public record ProductInfo(
+        UUID productId,
+        String name
+) {
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/external/dto/UserDto.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/external/dto/UserDto.java
@@ -1,4 +1,4 @@
-package site.leesoyeon.avalanche.point.client.dto;
+package site.leesoyeon.avalanche.point.infrastructure.external.dto;
 
 import java.util.UUID;
 

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/presentation/repository/PointTransactionRepository.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/presentation/repository/PointTransactionRepository.java
@@ -1,0 +1,12 @@
+package site.leesoyeon.avalanche.point.infrastructure.presentation.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.leesoyeon.avalanche.point.domain.model.PointTransaction;
+
+
+import java.util.UUID;
+
+public interface PointTransactionRepository extends JpaRepository<PointTransaction, UUID>, PointTransactionRepositoryCustom {
+
+    PointTransaction findTopByUserIdOrderByCreatedDateDesc(UUID userId);
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/presentation/repository/PointTransactionRepositoryCustom.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/presentation/repository/PointTransactionRepositoryCustom.java
@@ -1,0 +1,19 @@
+package site.leesoyeon.avalanche.point.infrastructure.presentation.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import site.leesoyeon.avalanche.point.presentation.dto.PointTransactionSearchCondition;
+import site.leesoyeon.avalanche.point.presentation.dto.PointTransactionSummaryDto;
+import site.leesoyeon.avalanche.point.domain.model.PointTransaction;
+
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PointTransactionRepositoryCustom {
+
+    List<PointTransaction> findPointTransactionWithCondition(PointTransactionSearchCondition condition);
+    Page<PointTransactionSummaryDto> findAllByUserId(UUID userId, Pageable pageable);
+    Optional<Integer> findLatestActiveBalanceByUserId(UUID userId);
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/presentation/repository/PointTransactionRepositoryImpl.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/infrastructure/presentation/repository/PointTransactionRepositoryImpl.java
@@ -1,0 +1,127 @@
+package site.leesoyeon.avalanche.point.infrastructure.presentation.repository;
+
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import site.leesoyeon.avalanche.point.domain.model.QPointTransaction;
+import site.leesoyeon.avalanche.point.presentation.dto.PointTransactionSearchCondition;
+import site.leesoyeon.avalanche.point.presentation.dto.PointTransactionSummaryDto;
+import site.leesoyeon.avalanche.point.domain.model.PointTransaction;
+
+import site.leesoyeon.avalanche.point.shared.enums.ActivityType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class PointTransactionRepositoryImpl implements PointTransactionRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    QPointTransaction qPointTransaction = QPointTransaction.pointTransaction;
+
+    @Override
+    public Page<PointTransactionSummaryDto> findAllByUserId(UUID userId, Pageable pageable) {
+        List<PointTransactionSummaryDto> content = queryFactory
+                .select(Projections.constructor(
+                        PointTransactionSummaryDto.class,
+                        qPointTransaction.activityType,
+                        qPointTransaction.amount,
+                        qPointTransaction.balance,
+                        qPointTransaction.productId,
+                        qPointTransaction.description,
+                        qPointTransaction.expiryDate,
+                        qPointTransaction.createdDate
+                ))
+                .from(qPointTransaction)
+                .where(userIdEq(userId))
+                .orderBy(qPointTransaction.createdDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .select(qPointTransaction.count())
+                .from(qPointTransaction)
+                .where(userIdEq(userId))
+                .fetch().size();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public List<PointTransaction> findPointTransactionWithCondition(PointTransactionSearchCondition condition) {
+        return queryFactory
+                .selectFrom(qPointTransaction)
+                .where(
+                    userIdEq(condition.userId()),
+                        activityTypeEq(condition.activityType()),
+                        dateBetween(condition.startDate(), condition.endDate()),
+                        isCancelledEq(condition.isCancelled()),
+                        amountBetween(condition.minAmount(), condition.maxAmount())
+                )
+                .orderBy(qPointTransaction.createdDate.desc())
+                .fetch();
+    }
+
+    @Override
+    public Optional<Integer> findLatestActiveBalanceByUserId(UUID userId) {
+        Integer balance = queryFactory
+                .select(qPointTransaction.balance)
+                .from(qPointTransaction)
+                .where(
+                        qPointTransaction.userId.eq(userId),
+                        qPointTransaction.isCancelled.eq(false)
+                )
+                .orderBy(qPointTransaction.createdDate.desc())
+                .fetchFirst();
+
+        return Optional.ofNullable(balance);
+    }
+
+//  ============================================
+//              Condition Builders
+//  ============================================
+
+    private BooleanExpression userIdEq(UUID userId) {
+        return userId != null ? QPointTransaction.pointTransaction.userId.eq(userId) : null;
+    }
+
+    private BooleanExpression activityTypeEq(ActivityType activityType) {
+        return activityType != null ? QPointTransaction.pointTransaction.activityType.eq(activityType) : null;
+    }
+
+    private BooleanExpression dateBetween(LocalDateTime startDate, LocalDateTime endDate) {
+        if(startDate != null && endDate != null) {
+            return QPointTransaction.pointTransaction.createdDate.between(startDate, endDate);
+        } else if (startDate != null) {
+            return QPointTransaction.pointTransaction.createdDate.goe(startDate);
+        } else if (endDate != null) {
+            return QPointTransaction.pointTransaction.createdDate.loe(endDate);
+        } else {
+            return null;
+        }
+    }
+
+    private BooleanExpression isCancelledEq(Boolean isCancelled) {
+        return isCancelled != null ? QPointTransaction.pointTransaction.isCancelled.eq(isCancelled) : null;
+    }
+
+    private BooleanExpression amountBetween(Integer minAmount, Integer maxAmount) {
+        if(minAmount != null && maxAmount != null) {
+            return QPointTransaction.pointTransaction.amount.between(minAmount, maxAmount);
+        } else if (minAmount != null) {
+            return QPointTransaction.pointTransaction.amount.goe(minAmount);
+        } else if (maxAmount != null) {
+            return QPointTransaction.pointTransaction.amount.loe(maxAmount);
+        } else {
+            return null;
+        }
+    }
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/presentation/controller/PointTransactionController.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/presentation/controller/PointTransactionController.java
@@ -1,0 +1,76 @@
+package site.leesoyeon.avalanche.point.presentation.controller;
+
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import site.leesoyeon.avalanche.point.infrastructure.external.dto.OrderContext;
+import site.leesoyeon.avalanche.point.presentation.dto.ManualPointAdjustmentRequest;
+import site.leesoyeon.avalanche.point.presentation.dto.PointTransactionDetailDto;
+import site.leesoyeon.avalanche.point.presentation.dto.PointTransactionListDto;
+import site.leesoyeon.avalanche.point.application.service.PointDeductionService;
+import site.leesoyeon.avalanche.point.application.service.PointTransactionService;
+
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/points")
+@RequiredArgsConstructor
+public class PointTransactionController {
+
+    private final PointTransactionService pointTransactionService;
+    private final PointDeductionService pointDeductionService;
+
+    @PostMapping("/deduct")
+    public ResponseEntity<OrderContext> deductPoints(@RequestBody OrderContext context) {
+        return ResponseEntity.status(HttpStatus.OK).body(pointDeductionService.deductPoints(context));
+    }
+
+    @PostMapping("/refund")
+    public ResponseEntity<OrderContext> refundPoints(@RequestBody OrderContext context) {
+        return ResponseEntity.status(HttpStatus.OK).body(pointDeductionService.refundPoints(context));
+    }
+
+    /**
+     * 특정 포인트 거래의 세부 정보를 조회합니다.
+     *
+     * @param transactionId 조회할 거래의 고유 식별자
+     * @return 포인트 거래의 세부 정보를 담은 {@link ResponseEntity}
+     */
+    @GetMapping("/{transactionId}")
+    public ResponseEntity<PointTransactionDetailDto> getPointTransaction(
+            @PathVariable(value = "transactionId") UUID transactionId) {
+        PointTransactionDetailDto transactionDetail = pointTransactionService.getPointTransactionDetail(transactionId);
+        return ResponseEntity.status(HttpStatus.OK).body(transactionDetail);
+    }
+
+    /**
+     * 특정 사용자의 포인트 거래 목록을 페이지네이션하여 조회합니다.
+     *
+     * @param userId 조회할 사용자의 고유 식별자
+     * @param pageable 페이지네이션 정보
+     * @return 사용자의 포인트 거래 목록을 담은 {@link ResponseEntity}
+     */
+    @GetMapping("/{userId}/transactions")
+    public ResponseEntity<PointTransactionListDto> getUserPointTransactions(
+            @PathVariable UUID userId, Pageable pageable) {
+        PointTransactionListDto pointTransactionListDto = pointTransactionService.getPointTransactions(userId, pageable);
+        return ResponseEntity.ok(pointTransactionListDto);
+    }
+
+    /**
+     * 사용자의 포인트를 수동으로 조정합니다.
+     *
+     * @param request 포인트 조정 요청 객체
+     * @return 상태 코드를 담은 {@link ResponseEntity}
+     */
+    @PostMapping("/adjust")
+    public ResponseEntity<Void> adjustPointsManually(@RequestBody @Valid ManualPointAdjustmentRequest request) {
+        pointTransactionService.adjustPointsManually(request);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/presentation/dto/ManualPointAdjustmentRequest.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/presentation/dto/ManualPointAdjustmentRequest.java
@@ -1,0 +1,31 @@
+package site.leesoyeon.avalanche.point.presentation.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import site.leesoyeon.avalanche.point.shared.enums.ActivityType;
+
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public record ManualPointAdjustmentRequest(
+        @NotNull(message = "사용자 ID는 필수입니다.")
+        UUID userId,
+
+        @NotNull(message = "포인트 금액은 필수입니다.")
+        @Min(value = 1, message = "포인트 금액은 1 이상이어야 합니다.")
+        Integer amount,
+
+        @NotNull(message = "활동 유형은 필수입니다.")
+        ActivityType activityType,
+
+        UUID productId,
+
+        @Size(max = 500, message = "설명은 500자를 초과할 수 없습니다.")
+        String description,
+
+        LocalDateTime expiryDate
+) {}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/presentation/dto/PointTransactionDetailDto.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/presentation/dto/PointTransactionDetailDto.java
@@ -1,0 +1,38 @@
+package site.leesoyeon.avalanche.point.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import site.leesoyeon.avalanche.point.shared.enums.ActivityType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 포인트 트랜잭션의 상세 정보를 담는 DTO.
+ *
+ * @param transactionId 트랜잭션 고유 식별자
+ * @param userId 사용자 고유 식별자
+ * @param amount 트랜잭션 금액
+ * @param balance 트랜잭션 후 잔액
+ * @param activityType 트랜잭션 활동 유형
+ * @param productId 관련 상품 식별자 (있는 경우)
+ * @param description 트랜잭션 설명
+ * @param isCancelled 트랜잭션 취소 여부
+ * @param expiryDate 포인트 만료일 (있는 경우)
+ * @param createdDate 트랜잭션 생성 시간
+ */
+public record PointTransactionDetailDto(
+        @NotNull UUID transactionId,
+        @NotNull UUID userId,
+        @NotNull Integer amount,
+        @NotNull @PositiveOrZero Integer balance,
+        @NotNull ActivityType activityType,
+        UUID productId,
+        @Size(max = 500) String description,
+        boolean isCancelled,
+        LocalDate expiryDate,
+        @NotNull LocalDateTime createdDate
+) {
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/presentation/dto/PointTransactionListDto.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/presentation/dto/PointTransactionListDto.java
@@ -1,0 +1,15 @@
+package site.leesoyeon.avalanche.point.presentation.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.data.domain.Page;
+
+/**
+ * 페이지네이션된 포인트 트랜잭션 목록을 담는 DTO.
+ *
+ * @param transactions 페이지네이션된 트랜잭션 상세 정보 목록
+ */
+public record PointTransactionListDto(
+        @NotNull @Valid Page<PointTransactionSummaryDto> transactions
+) {
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/presentation/dto/PointTransactionSearchCondition.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/presentation/dto/PointTransactionSearchCondition.java
@@ -1,0 +1,32 @@
+package site.leesoyeon.avalanche.point.presentation.dto;
+
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.PositiveOrZero;
+import site.leesoyeon.avalanche.point.shared.enums.ActivityType;
+
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 포인트 트랜잭션 검색을 위한 조건을 담는 DTO.
+ *
+ * @param userId 검색할 사용자 ID
+ * @param activityType 검색할 활동 유형
+ * @param startDate 검색 시작 날짜
+ * @param endDate 검색 종료 날짜
+ * @param isCancelled 취소된 트랜잭션 포함 여부
+ * @param minAmount 최소 트랜잭션 금액
+ * @param maxAmount 최대 트랜잭션 금액
+ */
+public record PointTransactionSearchCondition(
+        UUID userId,
+        ActivityType activityType,
+        @Past LocalDateTime startDate,
+        @PastOrPresent LocalDateTime endDate,
+        Boolean isCancelled,
+        @PositiveOrZero Integer minAmount,
+        @PositiveOrZero Integer maxAmount
+) {
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/presentation/dto/PointTransactionSummaryDto.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/presentation/dto/PointTransactionSummaryDto.java
@@ -1,0 +1,21 @@
+package site.leesoyeon.avalanche.point.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import site.leesoyeon.avalanche.point.shared.enums.ActivityType;
+
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record PointTransactionSummaryDto(
+        @NotNull ActivityType activityType,
+        @NotNull Integer amount,
+        @NotNull @PositiveOrZero Integer balance,
+        UUID productId,
+        @Size(max = 500) String description,
+        LocalDateTime expiryDate,
+        @NotNull LocalDateTime createdDate
+) {
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/shared/api/ApiResponse.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/shared/api/ApiResponse.java
@@ -1,0 +1,30 @@
+package site.leesoyeon.avalanche.product.shared.api;
+
+import lombok.Getter;
+import site.leesoyeon.avalanche.point.shared.api.ApiStatus;
+
+@Getter
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final int statusCode;
+    private final String message;
+    private final String debugMessage;
+    private final T data;
+
+    private ApiResponse(ApiStatus apiStatus, T data, String debugMessage) {
+        this.success = apiStatus.getStatusCode() < 400;
+        this.statusCode = apiStatus.getStatusCode();
+        this.message = apiStatus.getMessage();
+        this.debugMessage = debugMessage;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> success(ApiStatus status, T data) {
+        return new ApiResponse<>(status, data, null);
+    }
+
+    public static <T> ApiResponse<T> error(ApiStatus status, String debugMessage) {
+        return new ApiResponse<>(status, null, debugMessage);
+    }
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/shared/api/ApiStatus.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/shared/api/ApiStatus.java
@@ -1,0 +1,30 @@
+package site.leesoyeon.avalanche.point.shared.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ApiStatus {
+
+    // 200 - Success
+    SUCCESS(200, "SU", "Success"),
+
+    // 400 - Bad Request : 잘못된 요청
+    INSUFFICIENT_POINTS(400, "IP", "포인트가 부족합니다."),
+    INVALID_POINT_AMOUNT(400, "IPA", "유효하지 않은 포인트 금액입니다."),
+
+    // 404 - Not Found : 잘못된 리소스 접근
+    NOT_FOUND_POINT_HISTORY(404, "NFPH", "포인트 내역을 찾을 수 없습니다."),
+
+    // 409 - Conflict : 중복 데이터
+    POINT_TRANSACTION_FAILED(409, "PTF", "포인트 거래 처리에 실패했습니다."),
+
+    // 500 - Internal Server Error
+    POINT_SYSTEM_ERROR(500, "PSE", "포인트 시스템 오류가 발생했습니다."),
+    INTERNAL_SERVER_ERROR(500,"ISE", "데이터베이스 연결 실패");
+
+    private final int statusCode;
+    private final String code;
+    private final String message;
+}

--- a/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/shared/enums/ActivityType.java
+++ b/avalanche-point/src/main/java/site/leesoyeon/avalanche/point/shared/enums/ActivityType.java
@@ -1,0 +1,22 @@
+package site.leesoyeon.avalanche.point.shared.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ActivityType {
+    EARN_LOGIN("로그인 포인트 적립"),
+    EARN_EVENT("이벤트 포인트 적립"),
+    EARN_PURCHASE("구매 포인트 적립"),
+    USE_RAFFLE("추첨 참여 포인트 사용"),
+    EXPIRE("포인트 만료"),
+    REFUND("포인트 환불"),
+    ADJUST_MANUAL("수동 포인트 조정"),
+    DEDUCT_ORDER("주문 시 포인트 차감"),
+    COMPENSATE_ORDER("주문 취소 포인트 보상");
+
+    private final String description;
+
+    ActivityType(String description) {
+        this.description = description;
+    }
+}


### PR DESCRIPTION
### 🔄 변경 사항
- 기존 모노리스 구조에서 마이크로서비스 아키텍처로 전환하여 코드 재배치.
- `application`, `domain`, `infrastructure`, `presentation`, `shared` 등 레이어별로 코드 분리.
- 각 레이어에 맞게 서비스, 리포지토리, DTO, 예외 처리, 설정 등을 재구성.
- 서비스의 모듈화 및 유지보수성 향상.

### 🔍 관련 이슈

### ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 코드 스타일을 준수했습니다.
- [ ] 문서화(README.md 등)가 필요한 경우 업데이트했습니다.

### 🧪 테스트 방법
- [x] 직접 실행해 봄
- [ ] 유닛 테스트 수행
- [ ] 통합 테스트 수행
- [ ] 코드 리뷰만으로 충분함
- [ ] 기타 (설명 필요)