### PR TITLE
[#43] ShippingService 마이크로서비스로 변환

### DIFF
--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/AvalancheShippingApplication.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/AvalancheShippingApplication.java
@@ -7,7 +7,7 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @EnableDiscoveryClient
 @SpringBootApplication
-@EnableFeignClients(basePackages = "site.leesoyeon.avalanche.shipping.client")
+@EnableFeignClients(basePackages = "site.leesoyeon.avalanche.shipping.infrastructure.external.client")
 public class AvalancheShippingApplication {
 
     public static void main(String[] args) {

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/application/service/ShippingCreationService.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/application/service/ShippingCreationService.java
@@ -1,0 +1,49 @@
+package site.leesoyeon.avalanche.shipping.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.leesoyeon.avalanche.shipping.infrastructure.external.dto.OrderContext;
+import site.leesoyeon.avalanche.shipping.domain.model.Shipping;
+import site.leesoyeon.avalanche.shipping.infrastructure.exception.ShippingInfoInvalidException;
+
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ShippingCreationService {
+
+    private final ShippingService shippingService;
+
+    @Transactional
+    public OrderContext createShipping(OrderContext context) {
+        try {
+            if (context.shippingInfo() == null ||
+                context.shippingInfo().recipientName() == null ||
+                context.shippingInfo().recipientName().isEmpty()) {
+                throw new ShippingInfoInvalidException("배송 정보가 올바르지 않습니다.");
+            }
+
+            Shipping shipping = shippingService.saveShipping(context.orderId(), context.shippingInfo());
+            log.info("배송지 생성 완료: {}", shipping.getShippingId());
+            return context.shippingCreated(shipping.getShippingId());
+        } catch (Exception e) {
+            return context.shippingCreationFailed("배송 생성 중 오류 발생: " + e.getMessage());
+        }
+    }
+
+    @Transactional
+    public OrderContext cancelShipping(OrderContext context) {
+        try {
+            if (context.shippingInfo() != null && context.shippingInfo().shippingId() != null) {
+                shippingService.deleteById(context.shippingInfo().shippingId());
+            }
+            log.info("배송지 삭제가 완료되었습니다");
+            return context.shippingCancelled();
+        } catch (Exception e) {
+            return context.shippingCreationFailed("배송 취소 중 오류 발생: " + e.getMessage());
+        }
+    }
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/application/service/ShippingService.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/application/service/ShippingService.java
@@ -1,0 +1,63 @@
+package site.leesoyeon.avalanche.shipping.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import site.leesoyeon.avalanche.shipping.infrastructure.external.client.OrderServiceClient;
+import site.leesoyeon.avalanche.shipping.infrastructure.external.dto.OrderDto;
+import site.leesoyeon.avalanche.shipping.shared.api.ApiStatus;
+import site.leesoyeon.avalanche.shipping.domain.model.ShippingInfo;
+import site.leesoyeon.avalanche.shipping.presentation.dto.ShippingStatusDto;
+import site.leesoyeon.avalanche.shipping.domain.model.Shipping;
+import site.leesoyeon.avalanche.shipping.infrastructure.exception.ShippingException;
+import site.leesoyeon.avalanche.shipping.infrastructure.persistence.repository.ShippingRepository;
+import site.leesoyeon.avalanche.shipping.application.util.ShippingMapper;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ShippingService {
+
+    private final ShippingRepository shippingRepository;
+    private final OrderServiceClient orderServiceClient;
+    private final ShippingMapper shippingMapper;
+
+    @Transactional
+    public void updateShippingStatus(ShippingStatusDto request) {
+        Shipping shipping = findById(request.shippingId());
+        shipping.updateStatus(request.status());
+
+        OrderDto order = orderServiceClient.findByShippingId(request.shippingId())
+                .orElseThrow(() -> new ShippingException(ApiStatus.NOT_FOUND_ORDER));
+
+        order = order.toBuilder()
+                .status(String.valueOf(request.status()))
+                .build();
+
+        orderServiceClient.updateOrder(order);
+    }
+
+    @Transactional
+    public Shipping saveShipping(UUID orderId, ShippingInfo shippingInfo) {
+        Shipping shipping = shippingMapper.toEntity(orderId, shippingInfo);
+        return shippingRepository.save(shipping);
+    }
+
+    @Transactional
+    public void deleteById(UUID shippingId) {
+        shippingRepository.deleteById(shippingId);
+    }
+
+//     ============================================
+//                 Protected Methods
+//     ============================================
+
+    protected Shipping findById(UUID shippingId) {
+        return shippingRepository.findById(shippingId).orElseThrow(() -> new ShippingException(ApiStatus.NOT_FOUND_ORDER));
+    }
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/application/util/Constants.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/application/util/Constants.java
@@ -1,0 +1,41 @@
+package site.leesoyeon.avalanche.shipping.application.util;
+
+/**
+ * 프로젝트 전반에서 사용되는 상수들을 정의한 클래스.
+ *
+ * <p>이 클래스는 API 관련, JWT 토큰, 이메일 처리, 캐시, 보안 등의 설정에 필요한 상수들을
+ * 포함합니다. 모든 필드는 정적(static)이며, 인스턴스화할 수 없습니다.</p>
+ */
+
+ public final class Constants {
+
+   // API
+   public static final String API_VERSION = "/api/v1";
+   public static final String SUCCESS_STATUS = "SUCCESS";
+   public static final String ERROR_STATUS = "ERROR";
+   public static final String CONTENT_TYPE_JSON = "application/json";
+
+   // 캐시
+   public static final String CACHE_KEY_PREFIX = "CACHE::SHIPPING::";
+   public static final long DEFAULT_CACHE_EXPIRE_TIME = 60 * 60L; // 1시간
+   public static final String CACHE_SHIPPING_ORDER = "SHIPPING_ORDER::";
+
+   // 배송 관련 상수
+   public static final String SHIPPING_ORDER_ID_HEADER = "Shipping-Order-Id";
+   public static final String SHIPPING_STATUS_PENDING = "PENDING";
+   public static final String SHIPPING_STATUS_IN_PROGRESS = "IN_PROGRESS";
+   public static final String SHIPPING_STATUS_COMPLETED = "COMPLETED";
+   public static final String SHIPPING_STATUS_CANCELLED = "CANCELLED";
+
+   public static final String SHIPPING_METHOD_STANDARD = "STANDARD";
+   public static final String SHIPPING_METHOD_EXPRESS = "EXPRESS";
+   public static final String SHIPPING_METHOD_OVERNIGHT = "OVERNIGHT";
+
+   public static final String SHIPPING_STARTED_MSG = "배송이 시작되었습니다.";
+   public static final String SHIPPING_COMPLETED_MSG = "배송이 완료되었습니다.";
+   public static final String SHIPPING_CANCELLED_MSG = "배송이 취소되었습니다.";
+
+    private Constants() {
+        throw new IllegalStateException("이 클래스는 인스턴스를 생성할 수 없습니다.");
+    }
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/application/util/ShippingMapper.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/application/util/ShippingMapper.java
@@ -1,0 +1,21 @@
+package site.leesoyeon.avalanche.shipping.application.util;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+import site.leesoyeon.avalanche.shipping.domain.model.ShippingInfo;
+import site.leesoyeon.avalanche.shipping.domain.model.Shipping;
+import site.leesoyeon.avalanche.shipping.shared.enums.ShippingStatus;
+
+import java.util.UUID;
+
+@Mapper(componentModel = "spring", imports = {ShippingStatus.class}, unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface ShippingMapper {
+
+    ShippingMapper INSTANCE = Mappers.getMapper(ShippingMapper.class);
+
+    @Mapping(target = "shippingId", ignore = true)
+    @Mapping(target = "status", constant = "PREPARING")
+    Shipping toEntity(UUID orderId, ShippingInfo shippingInfo);
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/domain/model/BaseTimeEntity.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/domain/model/BaseTimeEntity.java
@@ -1,0 +1,43 @@
+package site.leesoyeon.avalanche.shipping.domain.model;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * * BaseTimeEntity는 엔티티 클래스에 공통적으로 사용되는
+ * 생성 시간과 수정 시간을 자동으로 관리하기 위한
+ * 기본 클래스를 제공합니다.
+ *
+ * <p>* 이 클래스를 상속받는 엔티티 클래스는
+ * 해당 엔티티가 생성되거나 수정될 때
+ * 자동으로 시간을 기록하게 됩니다.</p>
+ *
+ * <pre>{@code
+ * //예시
+ * @Entity
+ * public class User extends BaseTimeEntity {
+ *     // 사용자 필드들...
+ * }
+ * }</pre>
+ */
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/domain/model/Shipping.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/domain/model/Shipping.java
@@ -1,0 +1,68 @@
+package site.leesoyeon.avalanche.shipping.domain.model;
+
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import site.leesoyeon.avalanche.shipping.shared.enums.ShippingStatus;
+
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "shipping")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Shipping extends BaseTimeEntity {
+
+    @Id
+    @UuidGenerator
+    @Column(name = "shipping_id", updatable = false, nullable = false)
+    private UUID shippingId;
+
+    @Column(name = "order_id", nullable = false)
+    private UUID orderId;
+
+    @NotBlank(message = "Recipient name must not be blank")
+    @Column(name = "recipient_name", nullable = false)
+    private String recipientName;
+
+    @Column(name = "recipient_phone", nullable = false)
+    private String recipientPhone;
+
+    @Column(nullable = false)
+    private String address;
+
+    @Column(name = "detailed_address")
+    private String detailedAddress;
+
+    @Column(name = "zip_code", nullable = false)
+    private String zipCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ShippingStatus status;
+
+    public void updateStatus(ShippingStatus newStatus) {
+        this.status = newStatus;
+    }
+
+    public void updateRecipientInfo(String newName, String newPhone) {
+        this.recipientName = newName;
+        this.recipientPhone = newPhone;
+    }
+
+    public void updateAddress(String newAddress, String newDetailedAddress, String newZipCode) {
+        this.address = newAddress;
+        this.detailedAddress = newDetailedAddress;
+        this.zipCode = newZipCode;
+    }
+
+    public String getStatusDescription() {
+        return this.status.getDescription();
+    }
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/domain/model/ShippingInfo.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/domain/model/ShippingInfo.java
@@ -1,0 +1,48 @@
+package site.leesoyeon.avalanche.shipping.domain.model;
+
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder(toBuilder = true)
+public record ShippingInfo(
+        UUID shippingId,
+        String recipientName,
+        String recipientPhone,
+        String address,
+        String detailedAddress,
+        String zipCode,
+
+        boolean success,
+        String errorMessage,
+        String state,
+        boolean shippingStepCompleted
+) {
+    // 사가 실패 시 호출
+    public ShippingInfo fail(String errorMessage) {
+        return this.toBuilder()
+                .success(false)
+                .errorMessage(errorMessage)
+                .state("FAILED")
+                .build();
+    }
+
+    //===================================
+    //           배송 관리 메서드
+    //===================================
+
+    // 배송 생성 시 호출
+    public ShippingInfo shippingCreated(UUID shippingId) {
+        return this.toBuilder()
+                .state("SHIPPING_CREATED")
+                .shippingStepCompleted(true)
+                .build();
+    }
+
+    // 배송 취소 시 호출
+    public ShippingInfo shippingCancelled() {
+        return this.toBuilder()
+                .shippingStepCompleted(false)
+                .build();
+    }
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/config/LoggingAspect.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/config/LoggingAspect.java
@@ -1,0 +1,43 @@
+package site.leesoyeon.avalanche.shipping.infrastructure.config;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * 이 클래스는 AOP(Aspect-Oriented Programming)를 사용하여 메서드 실행 전후로 로깅을 수행하는 로깅 관점을 정의합니다.
+ *
+ * <p>로깅 관점은 애플리케이션의 특정 관심사를 모듈화하여 관리할 수 있게 해주며, 이 클래스는 특히 서비스 레이어의 메서드 실행 시간과
+ * 호출 정보를 로깅하는 데 사용됩니다. 이를 통해 성능 모니터링과 디버깅에 도움을 줄 수 있습니다.</p>
+ *
+ * <p>주요 기능:
+ * <ul>
+ *   <li>{@code @Around} - 지정된 패턴과 일치하는 메서드 실행 전후에 코드 블록을 실행합니다. 이 경우, 서비스 레이어의 모든 메서드 실행을 감싸고 있습니다.</li>
+ *   <li>{@code logMethodExecution} - 메서드 실행 전후에 실행 시간을 측정하고, 메서드 이름과 실행 시간을 로깅합니다.</li>
+ *   <li>로그는 SLF4J를 사용하여 기록되며, 메서드 실행 전에 시작 로그를, 실행 후에 완료 로그를 기록합니다.</li>
+ * </ul>
+ * </p>
+ *
+ * <p>이 설정을 통해 애플리케이션 내의 서비스 레이어에서 성능 문제를 파악하거나 특정 메서드 호출의 빈도와 실행 시간을 추적할 수 있습니다.</p>
+ */
+@Aspect
+@Component
+public class LoggingAspect {
+
+    private static final Logger logger = LoggerFactory.getLogger(LoggingAspect.class);
+
+    @Around("execution(* site.leesoyeon.avalanche.shipping..service.*.*(..))")
+    public Object logMethodExecution(ProceedingJoinPoint joinPoint) throws Throwable {
+        String methodName = joinPoint.getSignature().getName();
+        logger.info("Executing method: {}", methodName);
+        long start = System.currentTimeMillis();
+        Object result = joinPoint.proceed();
+        long executionTime = System.currentTimeMillis() - start;
+        logger.info("Executed method: {} in {} ms", methodName, executionTime);
+        return result;
+    }
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/config/StartupLogger.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/config/StartupLogger.java
@@ -1,0 +1,25 @@
+package site.leesoyeon.avalanche.shipping.infrastructure.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StartupLogger implements ApplicationListener<ApplicationReadyEvent> {
+    private static final Logger logger = LoggerFactory.getLogger(StartupLogger.class);
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        logger.info("===============================================");
+        logger.info("*     ❄️   *    *       *     ❄️    *      ️ ❄️");
+        logger.info("   *           ❄️   *     *     *        *    ");
+        logger.info(" *  /\\  PROJECT AVALANCHE SERVER STARTED!   *");
+        logger.info("   /  \\  *      *     ❄️     *     *         ");
+        logger.info(" *  ||  ❄️   *             *      ❄️    *    *");
+        logger.info("    ||    SPRING BOOT POWERED SNOW SYSTEM  *  ");
+        logger.info("   /||\\    *     *    *     *    *         ❄️");
+        logger.info("===============================================");
+    }
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/config/SwaggerConfig.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package site.leesoyeon.avalanche.shipping.infrastructure.config;
+
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Probability Reward API")
+                        .version("1.0.0")
+                        .description("This is the API documentation for My Awesome Project"));
+    }
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/exception/GlobalExceptionHandler.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/exception/GlobalExceptionHandler.java
@@ -1,26 +1,27 @@
-package site.leesoyeon.avalanche.point.infrastructure.exception;
+package site.leesoyeon.avalanche.shipping.infrastructure.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import site.leesoyeon.avalanche.point.shared.api.ApiResponse;
-import site.leesoyeon.avalanche.point.shared.api.ApiStatus;
+import site.leesoyeon.avalanche.shipping.shared.api.ApiResponse;
+import site.leesoyeon.avalanche.shipping.shared.api.ApiStatus;
+
 
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(PointTransactionException.class)
-    public ResponseEntity<ApiResponse<Void>> handleUserException(PointTransactionException ex) {
-        log.error("포인트 예외 발생: {}", ex.getMessage(), ex);
+    @ExceptionHandler(ShippingException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUserException(ShippingException ex) {
+        log.error("배송 예외 발생: {}", ex.getMessage(), ex);
         ApiResponse<Void> response = ApiResponse.error(ex.getStatus(), ex.getDebugMessage());
         return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getStatus().getStatusCode()));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<site.leesoyeon.avalanche.point.shared.api.ApiResponse<Void>> handleGenericException(Exception ex) {
+    public ResponseEntity<ApiResponse<Void>> handleGenericException(Exception ex) {
         log.error("예기치 않은 오류 발생: {}", ex.getMessage(), ex);
         ApiResponse<Void> response = ApiResponse.error(ApiStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/exception/ShippingException.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/exception/ShippingException.java
@@ -1,0 +1,24 @@
+package site.leesoyeon.avalanche.shipping.infrastructure.exception;
+
+
+import lombok.Getter;
+import site.leesoyeon.avalanche.shipping.shared.api.ApiStatus;
+
+@Getter
+public class ShippingException extends RuntimeException {
+
+    private final ApiStatus status;
+    private final String debugMessage;
+
+    public ShippingException(ApiStatus status) {
+        super(status.getMessage());
+        this.status = status;
+        this.debugMessage = null;
+    }
+
+    public ShippingException(ApiStatus status, String debugMessage) {
+        super(status.getMessage());
+        this.status = status;
+        this.debugMessage = debugMessage;
+    }
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/exception/ShippingInfoInvalidException.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/exception/ShippingInfoInvalidException.java
@@ -1,0 +1,26 @@
+package site.leesoyeon.avalanche.shipping.infrastructure.exception;
+
+/**
+ * 배송 정보가 유효하지 않을 때 발생하는 예외
+ */
+public class ShippingInfoInvalidException extends RuntimeException {
+
+    /**
+     * 지정된 오류 메시지로 새로운 ShippingInfoInvalidException을 생성합니다.
+     *
+     * @param message 오류 메시지
+     */
+    public ShippingInfoInvalidException(String message) {
+        super(message);
+    }
+
+    /**
+     * 지정된 오류 메시지와 원인으로 새로운 ShippingInfoInvalidException을 생성합니다.
+     *
+     * @param message 오류 메시지
+     * @param cause 예외의 원인
+     */
+    public ShippingInfoInvalidException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/external/client/OrderServiceClient.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/external/client/OrderServiceClient.java
@@ -1,0 +1,31 @@
+package site.leesoyeon.avalanche.shipping.infrastructure.external.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.*;
+import site.leesoyeon.avalanche.shipping.infrastructure.external.dto.OrderDto;
+import site.leesoyeon.avalanche.shipping.domain.model.ShippingInfo;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@FeignClient(name = "order-service")
+public interface OrderServiceClient {
+
+    @PutMapping("/api/v1/orders")
+    void updateOrder(@RequestBody OrderDto order);
+
+    @GetMapping("/api/v1/orders/shipping/{shippingId}")
+    Optional<OrderDto> findByShippingId(@PathVariable("shippingId") UUID shippingId);
+
+    @GetMapping("/api/v1/orders/{orderId}")
+    Optional<OrderDto> findById(@PathVariable("orderId") UUID orderId);
+
+    @PutMapping("/api/v1/orders/{orderId}")
+    void updateOrder(@PathVariable("orderId") UUID orderId, @RequestBody OrderDto orderDto);
+
+    @PatchMapping("/api/v1/orders/{orderId}/shipping")
+    void updateShippingInfo(@PathVariable("orderId") UUID orderId, @RequestBody ShippingInfo shippingInfo);
+
+    @DeleteMapping("/api/v1/orders/{orderId}/shipping")
+    void removeShippingInfo(@PathVariable("orderId") UUID orderId);
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/external/dto/OrderContext.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/external/dto/OrderContext.java
@@ -1,0 +1,69 @@
+package site.leesoyeon.avalanche.shipping.infrastructure.external.dto;
+
+import lombok.Builder;
+import site.leesoyeon.avalanche.shipping.domain.model.ShippingInfo;
+
+import java.util.UUID;
+
+@Builder(toBuilder = true)
+public record OrderContext(
+        UUID userId,
+        UUID orderId,
+        ShippingInfo shippingInfo,
+        SagaState state,
+
+        boolean shippingStepCompleted,
+
+        boolean success,
+        String errorMessage
+) {
+
+    //===================================
+    //           배송 관리 메서드
+    //===================================
+
+    // 배송 생성 시 호출
+    public OrderContext shippingCreated(UUID shippingId) {
+        ShippingInfo updatedShippingInfo = this.shippingInfo().toBuilder()
+                .shippingId(shippingId)
+                .build();
+
+        return this.toBuilder()
+                .state(SagaState.SHIPPING_REGISTERED)
+                .shippingStepCompleted(true)
+                .shippingInfo(updatedShippingInfo)
+                .success(true)
+                .build();
+    }
+
+    // 배송 생성 실패 시 호출
+    public OrderContext shippingCreationFailed(String errorMessage) {
+        return this.toBuilder()
+                .state(SagaState.SHIPPING_REGISTRATION_FAILED)
+                .shippingStepCompleted(false)
+                .success(false)
+                .errorMessage(errorMessage)
+                .build();
+    }
+
+    // 배송 취소 시 호출
+    public OrderContext shippingCancelled() {
+        return this.toBuilder()
+                .state(SagaState.SHIPPING_REGISTRATION_FAILED)
+                .shippingStepCompleted(false)
+                .shippingInfo(null)
+                .build();
+    }
+}
+
+enum SagaState {
+
+    SHIPPING_REGISTRATION_PENDING("배송지 등록이 대기 중입니다."),
+    SHIPPING_REGISTERED("배송지 정보가 성공적으로 등록되었습니다."),
+    SHIPPING_REGISTRATION_FAILED("배송지 등록에 실패했습니다.");
+
+    private final String description;
+    SagaState(String description) {
+        this.description = description;
+    }
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/external/dto/OrderDto.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/external/dto/OrderDto.java
@@ -1,0 +1,12 @@
+package site.leesoyeon.avalanche.shipping.infrastructure.external.dto;
+
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder(toBuilder = true)
+public record OrderDto(
+        UUID orderId,
+        String status
+) {
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/persistence/repository/ShippingRepository.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/infrastructure/persistence/repository/ShippingRepository.java
@@ -1,0 +1,12 @@
+package site.leesoyeon.avalanche.shipping.infrastructure.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import site.leesoyeon.avalanche.shipping.domain.model.Shipping;
+
+
+import java.util.UUID;
+
+@Repository
+public interface ShippingRepository extends JpaRepository<Shipping, UUID> {
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/presentation/controller/ShippingController.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/presentation/controller/ShippingController.java
@@ -1,0 +1,36 @@
+package site.leesoyeon.avalanche.shipping.presentation.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import site.leesoyeon.avalanche.shipping.infrastructure.external.dto.OrderContext;
+import site.leesoyeon.avalanche.shipping.presentation.dto.ShippingStatusDto;
+import site.leesoyeon.avalanche.shipping.application.service.ShippingCreationService;
+import site.leesoyeon.avalanche.shipping.application.service.ShippingService;
+
+
+@RestController
+@RequestMapping("/api/v1/shipping")
+@RequiredArgsConstructor
+public class ShippingController {
+
+    private final ShippingService shippingService;
+    private final ShippingCreationService shippingCreationService;
+
+    @PostMapping("/create")
+    public ResponseEntity<OrderContext> createShipping(@RequestBody OrderContext context) {
+        return ResponseEntity.status(HttpStatus.OK).body(shippingCreationService.createShipping(context));
+    }
+
+    @PostMapping("/cancel")
+    public ResponseEntity<OrderContext> cancelShipping(@RequestBody OrderContext context) {
+        return ResponseEntity.status(HttpStatus.OK).body(shippingCreationService.cancelShipping(context));
+    }
+
+    @PutMapping
+    public ResponseEntity<Void> updateShipping(@RequestBody ShippingStatusDto request) {
+        shippingService.updateShippingStatus(request);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/presentation/dto/ShippingStatusDto.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/presentation/dto/ShippingStatusDto.java
@@ -1,0 +1,11 @@
+package site.leesoyeon.avalanche.shipping.presentation.dto;
+
+import site.leesoyeon.avalanche.shipping.shared.enums.ShippingStatus;
+
+import java.util.UUID;
+
+public record ShippingStatusDto(
+        UUID shippingId,
+        ShippingStatus status
+) {
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/shared/api/ApiResponse.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/shared/api/ApiResponse.java
@@ -1,4 +1,4 @@
-package site.leesoyeon.avalanche.point.shared.api;
+package site.leesoyeon.avalanche.shipping.shared.api;
 
 import lombok.Getter;
 

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/shared/api/ApiStatus.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/shared/api/ApiStatus.java
@@ -1,0 +1,38 @@
+package site.leesoyeon.avalanche.shipping.shared.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ApiStatus {
+
+    // 200 - Success
+    SUCCESS(200, "SU", "Success"),
+
+    // 400 - Bad Request : 잘못된 요청
+    INVALID_INPUT_VALUE(400, "IIV", "입력 값이 잘못되었습니다."),
+    INVALID_SHIPPING_METHOD(400, "ISM", "유효하지 않은 배송 방법입니다."),
+    DUPLICATE_SHIPPING_REQUEST(400, "DSR", "중복된 배송 요청입니다."),
+
+    // 403 - Forbidden : 권한 없음 (서버가 요청을 이해했지만 승인을 거부)
+    NO_PERMISSION(403, "NP", "권한이 없습니다."),
+
+    // 404 - Not Found : 잘못된 리소스 접근
+    NOT_FOUND_SHIPPING_ADDRESS(404, "NFSA", "존재하지 않는 배송지입니다."),
+    NOT_FOUND_ORDER(404, "NFO", "주문 정보를 찾을 수 없습니다."),
+    NOT_FOUND_PRODUCT(404, "NFP", "존재하지 않는 상품입니다."),
+
+    // 409 - Conflict : 중복 데이터
+    CONFLICT_SHIPPING_ORDER(409, "CSO", "이미 배송이 시작된 주문입니다."),
+
+    // 500 - Internal Server Error
+    SHIPPING_SERVICE_ERROR(500, "SSE", "배송 서비스 처리 중 오류가 발생했습니다."),
+    DATABASE_ERROR(500, "DBE", "데이터베이스 오류"),
+    FAILED_SHIPPING_ACTION(500, "FSA", "배송 처리 중 오류가 발생했습니다."),
+    INTERNAL_SERVER_ERROR(500,"ISE", "데이터베이스 연결 실패");
+
+    private final int statusCode;
+    private final String code;
+    private final String message;
+}

--- a/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/shared/enums/ShippingStatus.java
+++ b/avalanche-shipping/src/main/java/site/leesoyeon/avalanche/shipping/shared/enums/ShippingStatus.java
@@ -1,0 +1,21 @@
+package site.leesoyeon.avalanche.shipping.shared.enums;
+
+
+import lombok.Getter;
+
+@Getter
+public enum ShippingStatus {
+
+    PREPARING("준비중"),
+    SHIPPED("출고완료"),
+    IN_TRANSIT("배송중"),
+    DELIVERED("배송완료"),
+    FAILED("배송실패"),
+    RETURNED("반송됨");
+
+    private final String description;
+
+    ShippingStatus(String description) {
+        this.description = description;
+    }
+}


### PR DESCRIPTION
### 🔄 변경 사항
- 기존 모노리스 구조에서 마이크로서비스 아키텍처로 전환하여 코드 재배치.
- `application`, `domain`, `infrastructure`, `presentation`, `shared` 등 레이어별로 코드 분리.
- 각 레이어에 맞게 서비스, 리포지토리, DTO, 예외 처리, 설정 등을 재구성.
- 서비스의 모듈화 및 유지보수성 향상.

### 🔍 관련 이슈

### ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 코드 스타일을 준수했습니다.
- [ ] 문서화(README.md 등)가 필요한 경우 업데이트했습니다.

### 🧪 테스트 방법
- [x] 직접 실행해 봄
- [ ] 유닛 테스트 수행
- [ ] 통합 테스트 수행
- [ ] 코드 리뷰만으로 충분함
- [ ] 기타 (설명 필요)